### PR TITLE
Make TransactionType a str enum instead of int

### DIFF
--- a/casparser/enums.py
+++ b/casparser/enums.py
@@ -17,7 +17,15 @@ class CASFileType(IntEnum):
     DETAILED = 2
 
 
-class TransactionType(Enum):
+class TransactionType(str, Enum):
+    # noinspection PyMethodParameters
+    def _generate_next_value_(name, start, count, last_values) -> str:  # type: ignore
+        """
+        Uses the name as the automatic value, rather than an integer
+        See https://docs.python.org/3/library/enum.html#using-automatic-values for reference
+        """
+        return name
+
     PURCHASE = auto()
     PURCHASE_SIP = auto()
     REDEMPTION = auto()


### PR DESCRIPTION
Fixes #36

Currently, when the detailed summary is exported, the transaction type with key "type" consists of the string version of the TransactionType Enum.
https://github.com/codereverser/casparser/blob/e2f14a09a1e9986951cbb91c75af75fd14e4a1e4/casparser/process/cas_detailed.py#L200

While this is the right design, if someone wants to reuse the `TransactionType` Enum elsewhere (like I am) on the exported data, this becomes a slight nuisance, as Json parsers like pydantic will not automatically parse the string into the Enum (as `TransactionType` is an Enum of ints). 

To allow for this, I am proposing changing TransactionType into a str based enum. By overriding `_generate_next_value_` method, we can make auto return the name of the Enum field as value instead of int. This way the value auto returns will be equal to the name it is being assigned and will be a string. This will allow those using `TransactionType` to recreate the overall object to directly import it without writing custom code to port the string to corresponding int in Enum.

This does not affect any other code as the enum can be accessed as is.

Additionally, the above mentioned line can be changed to `"type": txn_type.name` as now both  `txn_type` and `txn_type.name` will point to the same value.