### PR TITLE
Raise `IncorrectPasswordError` for invalid passwords

### DIFF
--- a/casparser/exceptions.py
+++ b/casparser/exceptions.py
@@ -10,6 +10,10 @@ class CASParseError(ParserException):
     """Error while parsing pdf file."""
 
 
+class IncorrectPasswordError(CASParseError):
+    """Incorrect password error."""
+
+
 class CASIntegrityError(ParserException):
     """Error while processing transactions"""
 

--- a/casparser/parsers/mupdf.py
+++ b/casparser/parsers/mupdf.py
@@ -8,7 +8,7 @@ from typing import List, Iterator, Union, Any
 import fitz
 
 from casparser.enums import FileType
-from casparser.exceptions import CASParseError
+from casparser.exceptions import CASParseError, IncorrectPasswordError
 from .utils import is_close, InvestorInfo, PartialCASData
 
 
@@ -197,7 +197,7 @@ def cas_pdf_to_text(filename: Union[str, io.IOBase], password) -> PartialCASData
         if doc.needsPass:
             rc = doc.authenticate(password)
             if not rc:
-                raise CASParseError("Incorrect PDF password!")
+                raise IncorrectPasswordError("Incorrect PDF password!")
 
         pages = []
         investor_info = None

--- a/casparser/parsers/pdfminer.py
+++ b/casparser/parsers/pdfminer.py
@@ -11,7 +11,7 @@ from pdfminer.pdfpage import PDFPage
 from pdfminer.layout import LTTextBoxHorizontal, LTTextBoxVertical
 
 from casparser.enums import FileType
-from casparser.exceptions import CASParseError
+from casparser.exceptions import CASParseError, IncorrectPasswordError
 from .utils import is_close, InvestorInfo, PartialCASData
 
 
@@ -122,7 +122,7 @@ def cas_pdf_to_text(filename: Union[str, io.IOBase], password) -> PartialCASData
         try:
             document = PDFDocument(pdf_parser, password=password)
         except PDFPasswordIncorrect:
-            raise CASParseError("Incorrect PDF password!")
+            raise IncorrectPasswordError("Incorrect PDF password!")
         except PDFSyntaxError:
             raise CASParseError("Unhandled error while opening file")
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 import pytest
 
 from casparser import read_cas_pdf
-from casparser.exceptions import CASParseError
+from casparser.exceptions import CASParseError, IncorrectPasswordError
 
 
 class BaseTestClass:
@@ -75,7 +75,7 @@ class BaseTestClass:
             assert re.search(r"Error\s+:\s+0\s+schemes", clean_output) is not None
 
     def test_invalid_password(self):
-        with pytest.raises(CASParseError) as exc_info:
+        with pytest.raises(IncorrectPasswordError) as exc_info:
             self.read_pdf(self.cams_file_name, "")
         assert "Incorrect PDF password!" in str(exc_info)
 


### PR DESCRIPTION
fixes #39 