### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1 - 2021-07-21
+- gains: PnL report
+- support for migration of Franklin Templeton funds to CAMS RTA
+- various bug fixes
+
 ## 0.5.0 - 2021-07-02
 - Support for calculating capital gains from detailed CAS statements
 - support for parsing Tax Deducted at Source (`TDS`) transactions

--- a/casparser/analysis/gains.py
+++ b/casparser/analysis/gains.py
@@ -187,7 +187,7 @@ class FIFOUnits:
                 TransactionType.STAMP_DUTY_TAX.name,
             ):
                 merged_transactions[dt].tax += txn["amount"]
-            else:
+            elif txn["units"] is not None:
                 merged_transactions[dt].nav = txn["nav"]
                 merged_transactions[dt].units += txn["units"]
                 merged_transactions[dt].amount += txn["amount"]

--- a/casparser/cli.py
+++ b/casparser/cli.py
@@ -194,6 +194,12 @@ def print_gains(data, output_file_path=None):
             fp.write(cg.get_gains_csv_data())
             console.print(f"Detailed gains report saved : [bold]{fname}[/]")
 
+    console.print(f"\n[bold]PnL[/] as of [bold]{data['statement_period']['to']}[/]")
+    console.print(f"{'Total Invested':20s}: [bold]₹{cg.invested_amount:,.2f}[/]")
+    console.print(f"{'Current Valuation':20s}: [bold]₹{cg.current_value:,.2f}[/]")
+    pnl = cg.current_value - cg.invested_amount
+    console.print(f"{'Absolute PnL':20s}: [bold {get_color(pnl)}]₹{pnl:,.2f}[/]")
+
 
 @click.command(name="casparser", context_settings=CONTEXT_SETTINGS)
 @click.option(
@@ -235,7 +241,7 @@ def cli(output, summary, password, include_all, gains, force_pdfminer, filename)
     if output is not None:
         output_ext = os.path.splitext(output)[-1].lower()
 
-    if not (summary or output_ext in (".csv", ".json")):
+    if not (summary or gains or output_ext in (".csv", ".json")):
         summary = True
     try:
         with Progress(

--- a/casparser/process/cas_detailed.py
+++ b/casparser/process/cas_detailed.py
@@ -58,7 +58,7 @@ def get_transaction_type(
         else:
             txn_type = TransactionType.PURCHASE
     elif units < 0:
-        if re.search("reversal|rejection|dishonoured", description, re.I):
+        if re.search("reversal|rejection|dishonoured|mismatch", description, re.I):
             txn_type = TransactionType.REVERSAL
         elif "switch" in description:
             if "merger" in description:

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,7 +22,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "casparser-isin"
-version = "2021.7.1"
+version = "2021.7.21"
 description = "ISIN database for casparser"
 category = "main"
 optional = false
@@ -243,7 +243,7 @@ testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtuale
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.1"
+version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
 category = "main"
 optional = false
@@ -262,7 +262,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "rich"
-version = "10.5.0"
+version = "10.6.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
@@ -314,7 +314,7 @@ mupdf = ["PyMuPDF"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d5557cd0cf74acb4c049dbe06ab03c51852b469945fe6922a103d59b2e959ece"
+content-hash = "bf4769ba07c103c3f48c30c7d607cd4226a81b944121baabdaeceb16c07c32ca"
 
 [metadata.files]
 atomicwrites = [
@@ -326,8 +326,8 @@ attrs = [
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 casparser-isin = [
-    {file = "casparser_isin-2021.7.1-py3-none-any.whl", hash = "sha256:dd419a7a55243dd88b489dc994dabc63b140408bea6550d3caeefd789ca06632"},
-    {file = "casparser_isin-2021.7.1.tar.gz", hash = "sha256:674a7c5a68bbdf4bcf55bda5a471c380a7f93e85c2f6a92a771f91d14077dff0"},
+    {file = "casparser_isin-2021.7.21-py3-none-any.whl", hash = "sha256:ff517e7a3a2990c4084cc43cd55ba86d4af81278b4b537cc133851b223f8169a"},
+    {file = "casparser_isin-2021.7.21.tar.gz", hash = "sha256:9e8b3043c62a028685e28a1a9d730ae193f18154339d75cdeea1ed6cc389e1cc"},
 ]
 cffi = [
     {file = "cffi-1.14.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:22b9c3c320171c108e903d61a3723b51e37aaa8c81255b5e7ce102775bd01e2c"},
@@ -515,8 +515,8 @@ pytest-cov = [
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
 python-dateutil = [
-    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
-    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 rapidfuzz = [
     {file = "rapidfuzz-1.4.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:72878878d6744883605b5453c382361716887e9e552f677922f76d93d622d8cb"},
@@ -582,8 +582,8 @@ rapidfuzz = [
     {file = "rapidfuzz-1.4.1.tar.gz", hash = "sha256:de20550178376d21bfe1b34a7dc42ab107bb282ef82069cf6dfe2805a0029e26"},
 ]
 rich = [
-    {file = "rich-10.5.0-py3-none-any.whl", hash = "sha256:d36d4dddbb6cb87cdcb2c02f8ffd7836e1b136e3ba45d4b5a4da057f3b5e7798"},
-    {file = "rich-10.5.0.tar.gz", hash = "sha256:f8a16484b3d70708bdafd04f659f9ca0e2c0129b33a343c10c734838d361777f"},
+    {file = "rich-10.6.0-py3-none-any.whl", hash = "sha256:d3f72827cd5df13b2ef7f1a97f81ec65548d4fdeb92cef653234f227580bbb2a"},
+    {file = "rich-10.6.0.tar.gz", hash = "sha256:128261b3e2419a4ef9c97066ccc2abbfb49fa7c5e89c3fe4056d00aa5e9c1e65"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "casparser"
-version = "0.5.0"
+version = "0.5.1"
 description = "(Karvy/Kfintech/CAMS) Consolidated Account Statement (CAS) PDF parser"
 authors = ["Sandeep Somasekharan <codereverser@gmail.com>"]
 homepage = "https://github.com/codereverser/casparser"
@@ -17,7 +17,7 @@ include = [ "CHANGELOG.md" ]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-casparser-isin = ">=2021.7.1"
+casparser-isin = ">=2021.7.21"
 click = "^8.0.1"
 colorama = "^0.4.4"
 "pdfminer.six" = "20201018"


### PR DESCRIPTION
- [x] classify transaction as `REVERSAL` when transaction is rejected due to mandate issues
- [x] ignore transactions with no units for capital gains calculations
- [x] support Franklin Templeton migration to CAMS RTA (while keeping the support for old PDF files intact). fixes #42 