### PR TITLE
Format number output with comma separator in column for Reported units to aid in readibility

### DIFF
--- a/casparser/cli.py
+++ b/casparser/cli.py
@@ -38,6 +38,10 @@ def formatINR(number):
     return f"{prefix[is_negative]}₹{value}"
 
 
+def format_number(number):
+    return f"{number:,}"
+
+
 def validate_fy(ctx, param, value):
     return re.search(r"FY\d{4}-\d{2,4}", value, re.I) is not None
 
@@ -137,10 +141,13 @@ def print_summary(parsed_data: CASData, output_filename=None, include_zero_folio
                 )
                 folio_header_added = True
 
+            scheme_close = scheme["close"]
+
             console_row = {
                 "scheme": scheme_name,
                 "open": scheme["open"],
-                "close": scheme["close"] if is_summary else f"{scheme['close']}\n/\n{calc_close}",
+                "close": format_number(scheme_close) if is_summary
+                            else f"{format_number(scheme_close)}\n/\n{calc_close}",
                 "value": f"{formatINR(valuation['value'])}\n@\n{formatINR(valuation['nav'])}",
                 "txns": len(scheme["transactions"]),
                 "status": status,

--- a/tests/casparser/test_cli.py
+++ b/tests/casparser/test_cli.py
@@ -4,3 +4,4 @@ from casparser.cli import format_number
 def test_format_number():
     assert format_number(100) == "100"
     assert format_number(1000) == "1,000"
+    assert format_number(102312) == "102,312"

--- a/tests/casparser/test_cli.py
+++ b/tests/casparser/test_cli.py
@@ -1,0 +1,6 @@
+from casparser.cli import format_number
+
+
+def test_format_number():
+    assert format_number(100) == "100"
+    assert format_number(1000) == "1,000"


### PR DESCRIPTION
- Addition for a number formatter to aid in visual representation of the units outputted such as `102,312` rather than `102312`
