### PR TITLE
Update `SCHEME_RE` to capture non-space RTA Codes

### DIFF
--- a/casparser/process/regex.py
+++ b/casparser/process/regex.py
@@ -24,7 +24,7 @@ NOMINEE_RE = r"\s*Nominee\s+[1-3]\s*:\s*(.*?)" * 3 + r"$"
 
 SCHEME_RE = (
     r"(?P<code>[\s\w]+-*[gdp]?)-\s*\d*\s*(?P<name>.+?)(?:\t\t|\(\s*Advis|ISIN).*?"
-    r"Registrar\s*:\s*(?P<rta>.*)\s*$"
+    r"Registrar\s*:\s*(?P<rta>[^\s]*).*$"
 )
 SCHEME_KV_RE = r"""(\w+)\s*:\s*([-\w]+)"""
 


### PR DESCRIPTION
Updated the Scheme regex regex pattern to include only non-space characters in the group. Rest of the code seems to be working fine with this change.

Closes #111 