### PR TITLE
[add]: Add important fields to mutual fund type

### DIFF
--- a/casparser/types.py
+++ b/casparser/types.py
@@ -128,6 +128,12 @@ class MutualFund(BaseModel):
     balance: Decimal
     nav: Decimal
     value: Decimal
+    avg_cost: Optional[Decimal] = None
+    total_cost: Optional[Decimal] = None
+    ucc: Optional[str] = None
+    folio: Optional[str] = None
+    pnl: Optional[Decimal] = None
+    return_: Optional[Decimal] = Field(None, alias="return")
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
Earlier I was not getting important mutual fund fields like avg_cost, total_cost, return, etc
<img width="939" height="47" alt="image" src="https://github.com/user-attachments/assets/8d478438-99c9-4fdc-b282-84062be4b739" />

I have added these values to Mutual Fund type after which I started getting it
<img width="933" height="87" alt="Screenshot 2025-09-23 180215" src="https://github.com/user-attachments/assets/1704d624-6470-44db-b48e-66c60be7c8ed" />


It was present in the nsdl_statement.py

```
elif current_demat["type"] == "MF":
            if m := re.search(
                NSDL_MF_HOLDINGS_RE,
                line,
                re.DOTALL | re.MULTILINE | re.I,
            ):
                isin, ucc, name, folio, units, avg_cost, total_cost, nav, value, pnl, returns = (
                    m.groups()
                )
                name = re.sub(r"\s+", " ", name).strip()
                name = re.sub(r"[^a-zA-Z0-9_)]+$", "", name).strip()
                current_demat["mutual_funds"].append(
                    {
                        "isin": isin,
                        "ucc": ucc,
                        "name": name,
                        "folio": folio,
                        "balance": units,
                        "avg_cost": avg_cost,
                        "total_cost": total_cost,
                        "nav": nav,
                        "value": value,
                        "pnl": pnl,
                        "return": returns,
                    }
                )
 ```
 
 but not in the types
