### PR TITLE
Fix CDSL CAS header parsing (statement period beyond first 1000 chars)

### DIFF
--- a/casparser/process/__init__.py
+++ b/casparser/process/__init__.py
@@ -25,7 +25,7 @@ def process_cas_text(text, file_type: FileType = FileType.UNKNOWN) -> ProcessedC
     :param text:
     :return:
     """
-    if file_type == FileType.NSDL:
+    if file_type in (FileType.NSDL, FileType.CDSL):
         return process_nsdl_text(text)
     cas_statement_type = detect_cas_type(text[:1000])
     if cas_statement_type == CASFileType.DETAILED:

--- a/casparser/process/nsdl_statement.py
+++ b/casparser/process/nsdl_statement.py
@@ -12,6 +12,7 @@ from .regex import (
     DEMAT_HEADER_RE,
     DEMAT_MF_HEADER_RE,
     DEMAT_MF_TYPE_RE,
+    DEMAT_STATEMENT_PERIOD_ALT_RE,
     DEMAT_STATEMENT_PERIOD_RE,
     NSDL_CDSL_HOLDINGS_RE,
     NSDL_EQ_RE,
@@ -19,15 +20,25 @@ from .regex import (
     NSDL_MF_RE,
 )
 
+# Search window for statement period (CDSL/NSDL block order can put it after 1000 chars)
+_HEADER_SEARCH_LEN = 5000
+
 
 def parse_header(text):
     """
     Parse CAS header data.
     :param text: CAS text
     """
+    search_text = text[:_HEADER_SEARCH_LEN]
     if m := re.search(
         DEMAT_STATEMENT_PERIOD_RE,
-        text,
+        search_text,
+        re.DOTALL | re.MULTILINE | re.I,
+    ):
+        return m.groupdict()
+    if m := re.search(
+        DEMAT_STATEMENT_PERIOD_ALT_RE,
+        search_text,
         re.DOTALL | re.MULTILINE | re.I,
     ):
         return m.groupdict()
@@ -35,7 +46,7 @@ def parse_header(text):
 
 
 def process_nsdl_text(text):
-    hdr_data = parse_header(text[:1000])
+    hdr_data = parse_header(text)
     statement_period = StatementPeriod(from_=hdr_data["from"], to=hdr_data["to"])
     accounts = re.findall(
         DEMAT_HEADER_RE,

--- a/casparser/process/regex.py
+++ b/casparser/process/regex.py
@@ -54,6 +54,11 @@ DEMAT_STATEMENT_PERIOD_RE = (
     r"for\s+the\s+period\s+from\s+(?P<from>\d{2}-[a-zA-Z0-9]{2,3}-\d{4})"
     r"\s+to\s+(?P<to>\d{2}-[a-zA-Z0-9]{2,3}-\d{4})"
 )
+# Alternate wording used in some CDSL statements (e.g. inbound)
+DEMAT_STATEMENT_PERIOD_ALT_RE = (
+    r"Statement\s+for\s+the\s+period\s+from\s+(?P<from>\d{2}-[a-zA-Z0-9]{2,3}-\d{4})"
+    r"\s+to\s+(?P<to>\d{2}-[a-zA-Z0-9]{2,3}-\d{4})"
+)
 DEMAT_HEADER_RE = (
     r"((?:CDSL|NSDL)\s+demat\s+account)\s+(.+?)\s*DP\s*Id\s*:\s*(.+?)"
     r"\s*Client\s*Id\s*:\s*(\d+)\s+(\d+)\s+([\d,.]+)"


### PR DESCRIPTION
- Widen header search window from 1000 to 5000 chars in nsdl_statement.parse_header
- Add DEMAT_STATEMENT_PERIOD_ALT_RE for "Statement for the period from ... to ..."
- Route FileType.CDSL to process_nsdl_text so CDSL statements use demat parser

Fixes HeaderParseError for CDSL inbound-style PDFs where the period line appears after the first 1000 characters in the mupdf-extracted text.