### PR TITLE
Fix: classify "Payment not received" transactions as REVERSAL

### DIFF
--- a/casparser/process/cas_detailed.py
+++ b/casparser/process/cas_detailed.py
@@ -100,7 +100,9 @@ def get_transaction_type(
             txn_type = TransactionType.PURCHASE
     elif units < 0:
         if re.search(
-            r"reversal|rejection|dishonoured|mismatch|insufficient\s+balance", description, re.I
+            r"reversal|rejection|dishonoured|mismatch|insufficient\s+balance|payment\s+not\s+received",
+            description,
+            re.I,
         ):
             txn_type = TransactionType.REVERSAL
         elif "switch" in description:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -66,6 +66,11 @@ class TestProcessClass:
             "Purchase SIPCheque Dishonoured - Instalment No 108", Decimal(-1.0)
         ) == (TransactionType.REVERSAL, None)
 
+        assert get_transaction_type(
+            "SIP Purchase151/Payment not received from investor Banker Physical - Instalment No 1",
+            Decimal(-1.365),
+        ) == (TransactionType.REVERSAL, None)
+
         assert parse_transaction(
             "01-Jan-2021\t\tCreation of units - Segregated Portfolio\t\t1.000\t\t12,601.184"
         ) == ParsedTransaction(


### PR DESCRIPTION

<img width="1727" height="144" alt="Screenshot 2026-06-01 at 6 44 57 PM" src="https://github.com/user-attachments/assets/235906f2-7c1a-4ae5-8d07-4c1d513fb6a7" />

Transactions where the SIP payment was not received were incorrectly classified as REDEMPTION. Added "payment not received" to the reversal detection regex alongside existing patterns like "dishonoured" and "rejection".